### PR TITLE
Replaced hyphens with spaces

### DIFF
--- a/usr/share/xubuntu/templates/po/hu.po
+++ b/usr/share/xubuntu/templates/po/hu.po
@@ -21,11 +21,11 @@ msgstr ""
 
 #: ../xdg-xubuntu-templates:30
 msgid "OpenDocument Text"
-msgstr "OpenDocument-szöveg"
+msgstr "OpenDocument szöveg"
 
 #: ../xdg-xubuntu-templates:31
 msgid "OpenDocument Spreadsheet"
-msgstr "OpenDocument-munkafüzet"
+msgstr "OpenDocument munkafüzet"
 
 #: ../xdg-xubuntu-templates:32
 msgid "Plain Text"


### PR DESCRIPTION
Hyphen wasn't used in the 'Plain Text' translation, so likely not needed here.