### PR TITLE
Setting Manager: Add Sound entry to Hardware section

### DIFF
--- a/etc/xdg/xdg-xubuntu/menus/xfce-settings-manager.menu
+++ b/etc/xdg/xdg-xubuntu/menus/xfce-settings-manager.menu
@@ -73,6 +73,7 @@
       </And>
       <Filename>nm-connection-editor.desktop</Filename>
       <Filename>system-config-printer.desktop</Filename>
+      <Filename>settings-hardware-sound.desktop</Filename>
     </Include>
   </Menu>
 

--- a/usr/share/xubuntu/applications/settings-hardware-sound.desktop.in
+++ b/usr/share/xubuntu/applications/settings-hardware-sound.desktop.in
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+_Name=Sound
+_Comment=Adjust the volume level
+_Keywords=Microphone;Volume;Fade;Balance;Headset;Speakers;Headphones;Audio;Mixer;Output;Input;Devices;Playback;Recording;System Sounds;Sound Card;Settings;Preferences;
+Icon=preferences-sound
+Exec=pavucontrol
+Actions=
+OnlyShowIn=XFCE;
+Categories=Settings;X-XFCE-HardwareSettings;X-XFCE-SettingsDialog;
+StartupNotify=true


### PR DESCRIPTION
Add entry launching pulseaudio's volumen control app into Settings Manager.
Mentioned in github issue #7.