### PR TITLE
set window size of file open/save dialog

### DIFF
--- a/debian/xubuntu-default-settings.gsettings-override
+++ b/debian/xubuntu-default-settings.gsettings-override
@@ -17,6 +17,7 @@ monospace-font-name='Monospace 10'
 
 [org.gtk.settings.file-chooser]
 window-size='(764, 482)'
+window-position='(19, 61)'
 
 [org.onboard]
 layout='Compact'

--- a/debian/xubuntu-default-settings.gsettings-override
+++ b/debian/xubuntu-default-settings.gsettings-override
@@ -15,6 +15,9 @@ icon-theme='elementary-xfce-darker'
 font-name='Noto Sans 9'
 monospace-font-name='Monospace 10'
 
+[org.gtk.settings.file-chooser]
+window-size='(764, 482)'
+
 [org.onboard]
 layout='Compact'
 theme='Nightshade'


### PR DESCRIPTION
Without this set, the dialog appears larger than the user's screen.