### PR TITLE
Add 'About System' to settings manager

### DIFF
--- a/etc/xdg/xdg-xubuntu/menus/xfce-applications.menu
+++ b/etc/xdg/xdg-xubuntu/menus/xfce-applications.menu
@@ -166,6 +166,7 @@
             <Or>
                 <Filename>xfce4-session-logout.desktop</Filename>
                 <Filename>org.gnome.Software.desktop</Filename>
+                <Filename>about-system.desktop</Filename>
             </Or>
         </Exclude>
     </Menu>

--- a/usr/share/xubuntu/applications/about-system.desktop
+++ b/usr/share/xubuntu/applications/about-system.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+_Name=About System
+_Comment=Displays details of the distribution, OS, CPU, graphics, memory, and Xfce
+_Keywords=operating system;hostname;desktop environment;hardware device;CPU;processor;GPU;graphics card driver;OpenGL;Mesa;RAM;memory;
+Icon=help-info
+Exec=xfce4-about
+Categories=Settings;X-XFCE-SettingsDialog;X-XFCE-SystemSettings;
+OnlyShowIn=XFCE;
+StartupNotify=true
+Terminal=false
+


### PR DESCRIPTION
Add entry for xfce4-about into Settings Manager.
Mentioned in github issue #7.