### PR TITLE
Hide Terminal Settings from Settings Manager

### DIFF
--- a/etc/xdg/xdg-xubuntu/menus/xfce-settings-manager.menu
+++ b/etc/xdg/xdg-xubuntu/menus/xfce-settings-manager.menu
@@ -54,6 +54,7 @@
       <Category>X-XFCE-SystemSettings</Category>
       <Filename>xfce4-settings-editor.desktop</Filename>
       <Filename>xfce-settings-manager.desktop</Filename>
+      <Filename>xfce4-terminal-settings.desktop</Filename>
     </Exclude>
   </Menu>
 


### PR DESCRIPTION
Suggestion made in https://github.com/Xubuntu/xubuntu-default-settings/issues/7