### PR TITLE
Unassigning Super + F

### DIFF
--- a/etc/xdg/xdg-xubuntu/xfce4/xfconf/xfce-perchannel-xml/xfce4-keyboard-shortcuts.xml
+++ b/etc/xdg/xdg-xubuntu/xfce4/xfconf/xfce-perchannel-xml/xfce4-keyboard-shortcuts.xml
@@ -20,7 +20,6 @@
       <property name="XF86Mail" type="string" value="exo-open --launch MailReader"/>
       <property name="&lt;Super&gt;m" type="string" value="exo-open --launch MailReader"/>
       <property name="XF86Explorer" type="string" value="exo-open --launch FileManager"/>
-      <property name="&lt;Super&gt;f" type="string" value="exo-open --launch FileManager"/>
       <property name="&lt;Super&gt;F1" type="string" value="xfce4-find-cursor"/>
       <property name="&lt;Primary&gt;&lt;Alt&gt;t" type="string" value="exo-open --launch TerminalEmulator"/>
       <property name="&lt;Super&gt;t" type="string" value="exo-open --launch TerminalEmulator"/>


### PR DESCRIPTION
As proposed in the [UI & UX Tweaks Google Doc](https://docs.google.com/document/d/1hzvQURi8l--GrfqsxP9c0tWNUzrkbZjZTiVxGUegALg/edit#heading=h.vdm5j6rpb6wb), Super + F is to be unassigned as Super + E was being assigned, as presently there are 4 shortcuts to open the file manager.

![image](https://user-images.githubusercontent.com/4412114/112715798-eb447600-8efb-11eb-8c96-3c23cde1874d.png)