### PR TITLE
fix super turning into caps when user swaps caps and esc

### DIFF
--- a/etc/xdg/xdg-xubuntu/autostart/xcape-super-binding.desktop
+++ b/etc/xdg/xdg-xubuntu/autostart/xcape-super-binding.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
 Type=Application
 Name=Bind Super Key
-Exec=xcape -e 'Super_L=Control_L|Escape'
+Exec=xcape -e 'Super_L=Alt_L|Pause'
 OnlyShowIn=XFCE;

--- a/etc/xdg/xdg-xubuntu/xfce4/xfconf/xfce-perchannel-xml/xfce4-keyboard-shortcuts.xml
+++ b/etc/xdg/xdg-xubuntu/xfce4/xfconf/xfce-perchannel-xml/xfce4-keyboard-shortcuts.xml
@@ -9,7 +9,7 @@
       <property name="&lt;Primary&gt;&lt;Alt&gt;Escape" type="string" value="xkill"/>
       <property name="XF86Display" type="string" value="xfce4-display-settings --minimal"/>
       <property name="&lt;Super&gt;p" type="string" value="xfce4-display-settings --minimal"/>
-      <property name="&lt;Primary&gt;Escape" type="string" value="xfce4-popup-whiskermenu"/>
+      <property name="&lt;Alt&gt;Pause" type="string" value="xfce4-popup-whiskermenu"/>
       <property name="&lt;Primary&gt;&lt;Shift&gt;Escape" type="string" value="xfce4-taskmanager"/>
       <property name="Print" type="string" value="xfce4-screenshooter -f"/>
       <property name="&lt;Alt&gt;Print" type="string" value="xfce4-screenshooter -w"/>


### PR DESCRIPTION
A PR form of the patches in [this](https://bugs.launchpad.net/ubuntu/+source/xubuntu-default-settings/+bug/1961506) bug report. Changes the xcape binding for super and it's matching shortcut for whiskermenu from `LCtrl+Esc` to `LAlt+Pause` to prevent super from turning into capslock when running commands like `setxkbmap -option caps:swapescape`