### PR TITLE
Use help-browser for xfhelp4 icon

### DIFF
--- a/usr/share/xubuntu/applications/xfhelp4.desktop.in
+++ b/usr/share/xubuntu/applications/xfhelp4.desktop.in
@@ -2,7 +2,7 @@
 Version=1.0
 Type=Application
 Exec=exo-open --launch WebBrowser /usr/share/xubuntu-docs/index.html
-Icon=gnome-help
+Icon=help-browser
 StartupNotify=false
 Terminal=false
 Categories=X-XFCE;X-Xfce-Toplevel;


### PR DESCRIPTION
Switches from legacy "gnome-help" to freedesktop
standard name "help-browser" for the xfhelp4 icon.
This name is used for the Xfce Help buttons and
is supported by more icon themes.