### PR TITLE
Icons: Use elementary-xfce-dark instead of darker

### DIFF
--- a/debian/xubuntu-default-settings.gsettings-override
+++ b/debian/xubuntu-default-settings.gsettings-override
@@ -11,7 +11,7 @@ picture-uri='file:///usr/share/xfce4/backdrops/xubuntu-wallpaper.png'
 
 [org.gnome.desktop.interface]
 gtk-theme='Greybird'
-icon-theme='elementary-xfce-darker'
+icon-theme='elementary-xfce-dark'
 font-name='Noto Sans 9'
 monospace-font-name='Monospace 10'
 

--- a/etc/xdg/xdg-xubuntu/xfce4/xfconf/xfce-perchannel-xml/xsettings.xml
+++ b/etc/xdg/xdg-xubuntu/xfce4/xfconf/xfce-perchannel-xml/xsettings.xml
@@ -3,7 +3,7 @@
 <channel name="xsettings" version="1.0">
   <property name="Net" type="empty">
     <property name="ThemeName" type="string" value="Greybird"/>
-    <property name="IconThemeName" type="string" value="elementary-xfce-darker"/>
+    <property name="IconThemeName" type="string" value="elementary-xfce-dark"/>
     <property name="FallbackIconTheme" type="string" value="gnome"/>
   </property>
   <property name="Xft" type="empty">


### PR DESCRIPTION
Switches to the `elementary-xfce` `dark` variant now that the `darker` variant has been deprecated.

https://github.com/shimmerproject/elementary-xfce/pull/352

---

I believe these are all the files where it should be changed. Please let me know if I'm missing any place else. Thanks!