### PR TITLE
Set matching Xfwm4 theme when selecting Gtk theme

### DIFF
--- a/etc/xdg/xdg-xubuntu/xfce4/xfconf/xfce-perchannel-xml/xsettings.xml
+++ b/etc/xdg/xdg-xubuntu/xfce4/xfconf/xfce-perchannel-xml/xsettings.xml
@@ -21,4 +21,7 @@
     <property name="FontName" type="string" value="Noto Sans 9"/>
     <property name="IconSizes" type="string" value="gtk-button=16,16"/>
   </property>
+  <property name="Xfce" type="empty">
+    <property name="SyncThemes" type="bool" value="true"/>
+  </property>
 </channel>


### PR DESCRIPTION
xfce4-appearance-settings 4.18 added an option to sync matching Xfwm4 theme (if available) when selecting a Gtk theme.

This enables that feature by default.

This is something I've seen new people, and a lot of youtube reviewers confused by (why the change in appearance didn't change the window border to match) so I think this would be helpful to have on by default.